### PR TITLE
Full import

### DIFF
--- a/src/_getMean.js
+++ b/src/_getMean.js
@@ -1,13 +1,6 @@
 import sum from "./utils/sum.js";
 import { arrayError, lengthError } from "./errors.js";
 
-/**
- * The mean (arithmetic mean) is a measure of central tendency of a finite set of numbers: specifically,
- * the sum of the values divided by the number of values.
- * -- [Wikipedia](https://en.wikipedia.org/wiki/Mean)
- * @param array {Array} - Array of numbers
- * @returns {Number} Mean of the given array
- **/
 export default function _getMean(array) {
   // Error handling
   arrayError(array);

--- a/src/_getMedian.js
+++ b/src/_getMedian.js
@@ -1,13 +1,6 @@
 import sort from "./utils/sort.js";
 import { arrayError } from "./errors.js";
-/**
- * The median is the value separating the higher half from the lower half of a data sample,
- * a population, or a probability distribution. For a data set,
- * it may be thought of as "the middle" value.
- * -- [Wikipedia](https://en.wikipedia.org/wiki/Median)
- * @param array {Array} - Array of numbers
- * @returns {Number} Median of the given array
- **/
+
 export default function _getMedian(array) {
   // Error handling
   arrayError(array);

--- a/src/getMean.js
+++ b/src/getMean.js
@@ -1,6 +1,15 @@
 import matrixArrayIterator from "./utils/matrixArrayIterator.js";
 import _getMean from "./_getMean.js";
 
+/**
+ * The mean (arithmetic mean) is a measure of central tendency of a finite set of numbers: specifically,
+ * the sum of the values divided by the number of values.
+ * -- [Wikipedia](https://en.wikipedia.org/wiki/Mean)
+ * @param data {Array} - Array of numbers
+ * @param axis {Number} - Axis across which to compute (0 is rows, 1 is columns). Default is rows.
+ * @returns {Number} Mean of the given array
+ **/
+
 export default function getMean(data, axis) {
   return matrixArrayIterator(data, axis, _getMean);
 }

--- a/src/getMedian.js
+++ b/src/getMedian.js
@@ -1,6 +1,16 @@
 import matrixArrayIterator from "./utils/matrixArrayIterator.js";
 import _getMedian from "./_getMedian.js";
 
+/**
+ * The median is the value separating the higher half from the lower half of a data sample,
+ * a population, or a probability distribution. For a data set,
+ * it may be thought of as "the middle" value.
+ * -- [Wikipedia](https://en.wikipedia.org/wiki/Median)
+ * @param data {Array} - Array of numbers
+ * @params axis {Number} - Axis across which to compute (0 is rows, 1 is columns). Default is rows.
+ * @returns {Number} Median of the given array
+ **/
+
 export default function getMedian(data, axis) {
   return matrixArrayIterator(data, axis, _getMedian);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -36,3 +36,52 @@ export { default as getKurtosis } from "./getKurtosis.js";
 
 // Utility functions
 export { default as matrixArrayIterator } from "./utils/matrixArrayIterator.js";
+
+// Export stats object
+import getMean from "./getMean.js";
+import getTrimmedMean from "./getTrimmedMean.js";
+import getHarmonicMean from "./getHarmonicMean.js";
+import getGeometricMean from "./getGeometricMean.js";
+import getWeightedMean from "./getWeightedMean.js";
+import getMedian from "./getMedian.js";
+import getMode from "./getMode.js";
+import getVariance from "./getVariance.js";
+import getStandDev from "./getStandDev.js";
+import getPercentile from "./getPercentile.js";
+import getQuartiles from "./getQuartiles.js";
+import getRange from "./getRange.js";
+import getIQR from "./getIQR.js";
+import getCoV from "./getCoV.js";
+import getMAD from "./getMAD.js";
+import getCorrCoeff from "./getCorrCoeff.js";
+import getZScore from "./getZScore.js";
+import getStandardError from "./getStandardError.js";
+import getKurtosis from "./getKurtosis.js";
+import getSkewness from "./getSkewness.js";
+import matrixArrayIterator from "./utils/matrixArrayIterator.js";
+
+const stats = {
+  getMean,
+  getTrimmedMean,
+  getHarmonicMean,
+  getGeometricMean,
+  getWeightedMean,
+  getMedian,
+  getMode,
+  getVariance,
+  getStandDev,
+  getPercentile,
+  getQuartiles,
+  getRange,
+  getIQR,
+  getCoV,
+  getMAD,
+  getCorrCoeff,
+  getZScore,
+  getStandardError,
+  getKurtosis,
+  getSkewness,
+  matrixArrayIterator,
+};
+
+export default stats;


### PR DESCRIPTION
These changes allows users to to import the full package or choose to import individual functions. They close #3. 

For instance, before changes:

```js
import { getMean, getVariance } from "summarystats"

cons data = [1, 2, 3, 4]

const mean = getMean(data)
const variance = getVariance(data)
```

After changes, the above method of import still exists but imports are expanded to allow:

```js
import stats from "summarystats"

const data = [1, 2, 3, 4]

const mean = stats.getMean(data)
const variance = stats.getVariance(data)
```